### PR TITLE
fixed error handling in GetUtxoStream

### DIFF
--- a/logic/logic.go
+++ b/logic/logic.go
@@ -315,7 +315,8 @@ func sendTo(sendTxParam transaction.SendTxParam, bc *lblockchain.Blockchain) ([]
 func GetUtxoStream(streamClient rpcpb.RpcServiceClient, getUTXORequest *rpcpb.GetUTXORequest) (*rpcpb.GetUTXOResponse, error) {
 	stream, err := streamClient.RpcGetUTXO(context.Background())
 	if err != nil {
-		logger.Error("get conversations stream err:", err)
+		//logger.Error("get conversations stream err:", err)
+		return nil, err
 	}
 	response := rpcpb.GetUTXOResponse{}
 	for {

--- a/logic/logic.go
+++ b/logic/logic.go
@@ -315,7 +315,6 @@ func sendTo(sendTxParam transaction.SendTxParam, bc *lblockchain.Blockchain) ([]
 func GetUtxoStream(streamClient rpcpb.RpcServiceClient, getUTXORequest *rpcpb.GetUTXORequest) (*rpcpb.GetUTXOResponse, error) {
 	stream, err := streamClient.RpcGetUTXO(context.Background())
 	if err != nil {
-		//logger.Error("get conversations stream err:", err)
 		return nil, err
 	}
 	response := rpcpb.GetUTXOResponse{}


### PR DESCRIPTION
Errors were not being passed up the chain correctly in GetUtxoStream, causing a crash for GetBalanceCommandHandler