### PR TITLE
resolve issues caused by errorManagement merge

### DIFF
--- a/core/utxo/utxo_cache_test.go
+++ b/core/utxo/utxo_cache_test.go
@@ -271,7 +271,7 @@ func TestUTXOCache_GetPreUtxo(t *testing.T) {
 
 	result, err := cache.GetPreUtxo("invalid")
 	assert.Nil(t, result)
-	assert.Equal(t, errors.New("key is invalid"), err)
+	assert.Equal(t, errval.InvalidKey, err)
 
 	result, err = cache.GetPreUtxo(utxo1.GetUTXOKey())
 	assert.Nil(t, result)
@@ -326,7 +326,7 @@ func TestUTXOCache_getUTXOInfo(t *testing.T) {
 
 	result, err = cache.getUTXOInfo("invalid key")
 	assert.Equal(t, &UTXOInfo{lastUTXOKey: []uint8{}, createContractUTXOKey: []uint8{}}, result)
-	assert.Equal(t, errors.New("key is invalid"), err)
+	assert.Equal(t, errval.InvalidKey, err)
 }
 
 func TestUTXOCache_deleteUTXOInfo(t *testing.T) {
@@ -350,7 +350,7 @@ func TestUTXOCache_deleteUTXOInfo(t *testing.T) {
 	assert.Nil(t, err)
 	result, err = cache.getUTXOInfo(pubKeyHash)
 	assert.Equal(t, &UTXOInfo{lastUTXOKey: []uint8{}, createContractUTXOKey: []uint8{}}, result)
-	assert.Equal(t, errors.New("key is invalid"), err)
+	assert.Equal(t, errval.InvalidKey, err)
 }
 
 func TestUTXOCache_deleteUTXOFromDB(t *testing.T) {
@@ -379,7 +379,7 @@ func TestUTXOCache_deleteUTXOFromDB(t *testing.T) {
 	assert.Nil(t, err)
 	result, err = cache.getUTXOFromDB(utxo.GetUTXOKey())
 	assert.Nil(t, result)
-	assert.Equal(t, errors.New("key is invalid"), err)
+	assert.Equal(t, errval.InvalidKey, err)
 }
 
 func TestUTXOCache_putLastUTXOKey(t *testing.T) {
@@ -459,7 +459,7 @@ func TestUTXOCache_putCreateContractUTXOKey(t *testing.T) {
 
 	// attempt to put to existing UTXOInfo
 	err = cache.putCreateContractUTXOKey(pubKeyHash, []byte("test_2"))
-	assert.Equal(t, errors.New("this utxoInfo already exists"), err)
+	assert.Equal(t, errval.UtxoInfoExists, err)
 }
 
 func TestUTXOCache_GetUtxoCreateContract(t *testing.T) {
@@ -561,7 +561,7 @@ func TestUTXOCache_SetPrevUtxoKey(t *testing.T) {
 	// utxo not in db
 	result, err := cache.SetPrevUtxoKey(util.Str2bytes(utxo.GetUTXOKey()), "test_0")
 	assert.Nil(t, result)
-	assert.Equal(t, errors.New("key is invalid"), err)
+	assert.Equal(t, errval.InvalidKey, err)
 
 	// successful update
 	err = cache.putUTXOToDB(utxo)
@@ -672,7 +672,7 @@ func TestUTXOCache_GetUTXOsByAmountWithOutRemovedUTXOs(t *testing.T) {
 			amount:         common.NewAmount(51),
 			utxoTxRemove:   nil,
 			expectedResult: nil,
-			expectedErr:    errors.New("transaction: insufficient balance"),
+			expectedErr:    errval.InsufficientFund,
 		},
 	}
 

--- a/logic/lblock/block_test.go
+++ b/logic/lblock/block_test.go
@@ -3,10 +3,11 @@ package lblock
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/dappley/go-dappley/crypto/keystore/secp256k1"
-	"github.com/dappley/go-dappley/logic/ltransaction"
 	"testing"
 	"time"
+
+	errval "github.com/dappley/go-dappley/errors"
+	"github.com/dappley/go-dappley/logic/ltransaction"
 
 	"github.com/dappley/go-dappley/core/scState"
 	"github.com/dappley/go-dappley/core/transaction"
@@ -267,7 +268,7 @@ func TestGenerateSignature(t *testing.T) {
 			key:         "bb23d2ff19f5b16955e8a24dca34dd520980fe3bddca2b3e1b56663f0ec1aa71",
 			data:        hash.Hash{0xde, 0xad, 0xbe, 0xef},
 			expectedRes: hash.Hash{},
-			expectedErr: secp256k1.ErrInvalidMsgLen,
+			expectedErr: errval.InvalidMsgLen,
 		},
 	}
 	for _, tt := range tests {

--- a/logic/ltransaction/transaction_logic.go
+++ b/logic/ltransaction/transaction_logic.go
@@ -20,18 +20,11 @@ import (
 )
 
 var (
-	ErrInvalidGasPrice = errors.New("invalid gas price, should be in (0, 10^12]")
-	ErrInvalidGasLimit = errors.New("invalid gas limit, should be in (0, 5*10^10]")
-
-	// vm error
-	ErrExecutionFailed       = errors.New("execution failed")
-	ErrUnsupportedSourceType = errors.New("unsupported source type")
-	ErrLoadError             = errors.New("contract load error")
-	GasConsumption           = 0
+	GasConsumption = 0
 )
 
 func SetGasConsumption(isOn bool) {
-	if !isOn{
+	if !isOn {
 		GasConsumption = -1
 	}
 }
@@ -55,7 +48,7 @@ func VerifyAndCollectContractOutput(utxoIndex *lutxo.UTXOIndex, tx *TxContract, 
 	if scEngine == nil {
 		return 0, nil, errval.MissingEngineManager
 	}
-	if tx.GasPrice.Cmp(common.NewAmount(0)) < 0 || tx.GasPrice.Cmp(common.NewAmount(0)) == GasConsumption{
+	if tx.GasPrice.Cmp(common.NewAmount(0)) < 0 || tx.GasPrice.Cmp(common.NewAmount(0)) == GasConsumption {
 		err := errval.NegativeGasPrice
 		logger.WithError(err).Error("CollectContractOutput: executeSmartContract error")
 		return 0, nil, err

--- a/rpc/grpc_host_integration_test.go
+++ b/rpc/grpc_host_integration_test.go
@@ -21,7 +21,6 @@
 package rpc
 
 import (
-	"errors"
 	"fmt"
 	errval "github.com/dappley/go-dappley/errors"
 
@@ -177,7 +176,7 @@ func GetUTXOsfromAmount(inputUTXOs []*utxo.UTXO, amount *common.Amount, tip *com
 	}
 
 	if sum.Cmp(amount) < 0 {
-		return nil, errval.ErrInsufficientFund
+		return nil, errval.InsufficientFund
 	}
 
 	return retUtxos, nil
@@ -619,7 +618,7 @@ func TestRpcGetBlockByHash(t *testing.T) {
 	response, err = c.RpcGetBlockByHash(context.Background(), &rpcpb.GetBlockByHashRequest{Hash: []byte("noexists")})
 	assert.Nil(t, response)
 	assert.Equal(t, codes.NotFound, status.Code(err))
-	assert.Equal(t, lblockchain.ErrBlockDoesNotExist.Error(), status.Convert(err).Message())
+	assert.Equal(t, errval.BlockDoesNotExist.Error(), status.Convert(err).Message())
 }
 
 func TestRpcGetBlockByHeight(t *testing.T) {
@@ -663,7 +662,7 @@ func TestRpcGetBlockByHeight(t *testing.T) {
 	response, err = c.RpcGetBlockByHeight(context.Background(), &rpcpb.GetBlockByHeightRequest{Height: tailBlock.GetHeight() + 1})
 	assert.Nil(t, response)
 	assert.Equal(t, codes.NotFound, status.Code(err))
-	assert.Equal(t, lblockchain.ErrBlockDoesNotExist.Error(), status.Convert(err).Message())
+	assert.Equal(t, errval.BlockDoesNotExist.Error(), status.Convert(err).Message())
 }
 
 func TestRpcVerifyTransaction(t *testing.T) {
@@ -682,7 +681,7 @@ func TestRpcVerifyTransaction(t *testing.T) {
 	}
 	//
 	utxoIndex := lutxo.NewUTXOIndex(rpcContext.bm.Getblockchain().GetUtxoCache())
-	if gctx, exists := ltransaction.NewGasChangeTx(account.NewTransactionAccountByAddress(fromAcc.GetAddress()), 0, common.NewAmount(uint64(0)), common.NewAmount(uint64(3000)), common.NewAmount(uint64(1)), 1);exists{
+	if gctx, exists := ltransaction.NewGasChangeTx(account.NewTransactionAccountByAddress(fromAcc.GetAddress()), 0, common.NewAmount(uint64(0)), common.NewAmount(uint64(3000)), common.NewAmount(uint64(1)), 1); exists {
 		utxoIndex.UpdateUtxo(&gctx)
 		utxoIndex.Save()
 	}
@@ -825,7 +824,7 @@ func TestRpcSendTransaction(t *testing.T) {
 	failedResponse, err := c.RpcSendTransaction(context.Background(), &rpcpb.SendTransactionRequest{Transaction: errTransaction.ToProto().(*transactionpb.Transaction)})
 	assert.Nil(t, failedResponse)
 	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
-	assert.Equal(t, lblockchain.ErrTransactionVerifyFailed.Error(), status.Convert(err).Message())
+	assert.Equal(t, errval.TransactionVerifyFailed.Error(), status.Convert(err).Message())
 
 	maxHeight = rpcContext.bm.Getblockchain().GetMaxHeight()
 	for (rpcContext.bm.Getblockchain().GetMaxHeight() - maxHeight) < 2 {

--- a/rpc/rpc_service.go
+++ b/rpc/rpc_service.go
@@ -20,10 +20,6 @@ package rpc
 import (
 	"context"
 
-	"github.com/dappley/go-dappley/consensus"
-	utxopb "github.com/dappley/go-dappley/core/utxo/pb"
-	"github.com/dappley/go-dappley/logic/lutxo"
-	"github.com/pkg/errors"
 	"io"
 	"strings"
 	"sync"
@@ -519,7 +515,7 @@ func (rpcService *RpcService) RpcContractQuery(ctx context.Context, in *rpcpb.Co
 	scState := scState.NewScState(rpcService.GetBlockchain().GetUtxoCache())
 	resultValue, exist := scState.GetStateValue(contractAddr, queryKey)
 	if !exist {
-		return nil, errors.New("key does not exist.")
+		return nil, errval.InvalidKey
 	}
 	return &rpcpb.ContractQueryResponse{Key: queryKey, Value: resultValue}, nil
 }


### PR DESCRIPTION
Merging the errorManagement caused a few errors from merge conflicts
and overlooked error values. This commit resolves those problems.